### PR TITLE
`ITopicRoutingService` Refactoring

### DIFF
--- a/Ignia.Topics.Tests/Ignia.Topics.Tests.csproj
+++ b/Ignia.Topics.Tests/Ignia.Topics.Tests.csproj
@@ -79,6 +79,10 @@
     <Compile Include="AttributeValueCollectionTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Ignia.Topics.Web.Mvc\Ignia.Topics.Web.Mvc.csproj">
+      <Project>{3b3ce34d-b5e5-47ca-bfef-e6740650f378}</Project>
+      <Name>Ignia.Topics.Web.Mvc</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Ignia.Topics\Ignia.Topics.csproj">
       <Project>{b8d5b290-4451-4c3b-ae9e-0ff075958a74}</Project>
       <Name>Ignia.Topics</Name>

--- a/Ignia.Topics.Tests/TopicRoutingServiceTest.cs
+++ b/Ignia.Topics.Tests/TopicRoutingServiceTest.cs
@@ -18,7 +18,7 @@ namespace Ignia.Topics.Tests {
   | CLASS: TOPIC ROUTING SERVICE TEST
   \---------------------------------------------------------------------------------------------------------------------------*/
   /// <summary>
-  ///   Provides unit tests for the <see cref="TopicRoutingService"/> class.
+  ///   Provides unit tests for the <see cref="MvcTopicRoutingService"/> class.
   /// </summary>
   [TestClass]
   public class TopicRoutingServiceTest {
@@ -55,11 +55,12 @@ namespace Ignia.Topics.Tests {
       routes.Values.Add("rootTopic", "Web");
       routes.Values.Add("path", "Web_0/Web_0_1/Web_0_1_2");
 
-      var topicRoutingService   = new TopicRoutingService(_topicRepository, uri, routes);
+      var topicRoutingService   = new MvcTopicRoutingService(_topicRepository, uri, routes);
+      var currentTopic          = topicRoutingService.GetCurrentTopic();
 
-      Assert.IsNotNull(topicRoutingService.Topic);
-      Assert.ReferenceEquals(topic, topicRoutingService.Topic);
-      Assert.AreEqual<string>("Web_0_1_2", topicRoutingService.Topic.Key);
+      Assert.IsNotNull(currentTopic);
+      Assert.ReferenceEquals(topic, currentTopic);
+      Assert.AreEqual<string>("Web_0_1_2", currentTopic.Key);
 
     }
 
@@ -77,11 +78,12 @@ namespace Ignia.Topics.Tests {
       var uri                   = new Uri("http://localhost/Web/Web_0/Web_0_1/Web_0_1_1");
       var topic                 = rootTopic.GetTopic("Root:Web:Web_0:Web_0_1:Web_0_1_1");
 
-      var topicRoutingService   = new TopicRoutingService(_topicRepository, uri, routes);
+      var topicRoutingService   = new MvcTopicRoutingService(_topicRepository, uri, routes);
+      var currentTopic          = topicRoutingService.GetCurrentTopic();
 
-      Assert.IsNotNull(topicRoutingService.Topic);
-      Assert.ReferenceEquals(topic, topicRoutingService.Topic);
-      Assert.AreEqual<string>("Web_0_1_1", topicRoutingService.Topic.Key);
+      Assert.IsNotNull(currentTopic);
+      Assert.ReferenceEquals(topic, currentTopic);
+      Assert.AreEqual<string>("Web_0_1_1", currentTopic.Key);
 
     }
 
@@ -90,7 +92,7 @@ namespace Ignia.Topics.Tests {
     \-------------------------------------------------------------------------------------------------------------------------*/
     /// <summary>
     ///   Establishes route data and ensures that those routes are available after initializing a new instance of the
-    ///   <see cref="TopicRoutingService"/>.
+    ///   <see cref="MvcTopicRoutingService"/>.
     /// </summary>
     [TestMethod]
     public void TopicRoutingService_RoutesTest() {
@@ -102,9 +104,10 @@ namespace Ignia.Topics.Tests {
       routes.Values.Add("rootTopic", "Web");
       routes.Values.Add("path", "Web_0/Web_0_1/Web_0_1_2");
 
-      var topicRoutingService   = new TopicRoutingService(_topicRepository, uri, routes);
+      var topicRoutingService   = new MvcTopicRoutingService(_topicRepository, uri, routes);
+      var currentTopic          = topicRoutingService.GetCurrentTopic();
 
-      Assert.IsNotNull(topicRoutingService.Topic);
+      Assert.IsNotNull(currentTopic);
       Assert.AreEqual<string>("Web", routes.GetRequiredString("rootTopic"));
       Assert.AreEqual<string>("Web_0/Web_0_1/Web_0_1_2", routes.GetRequiredString("path"));
       Assert.AreEqual<string>("Page", routes.GetRequiredString("contenttype"));

--- a/Ignia.Topics.Web.Mvc/Ignia.Topics.Web.Mvc.csproj
+++ b/Ignia.Topics.Web.Mvc/Ignia.Topics.Web.Mvc.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MvcTopicRoutingService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TopicController.cs" />
     <Compile Include="TopicViewEngine.cs" />

--- a/Ignia.Topics.Web.Mvc/TopicController.cs
+++ b/Ignia.Topics.Web.Mvc/TopicController.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Mvc;
+using System.Diagnostics.Contracts;
 using Ignia.Topics;
 using Ignia.Topics.Repositories;
 
@@ -28,6 +29,7 @@ namespace Ignia.Topics.Web.Mvc {
     | PRIVATE VARIABLES
     \-------------------------------------------------------------------------------------------------------------------------*/
     private                     ITopicRepository                _topicRepository                = null;
+    private                     ITopicRoutingService            _topicRoutingService            = null;
     private                     Topic                           _currentTopic                   = null;
 
     /*==========================================================================================================================
@@ -37,9 +39,20 @@ namespace Ignia.Topics.Web.Mvc {
     ///   Initializes a new instance of a Topic Controller with necessary dependencies.
     /// </summary>
     /// <returns>A topic controller for loading OnTopic views.</returns>
-    public TopicController(ITopicRepository topicRepository, Topic currentTopic) {
+    public TopicController(ITopicRepository topicRepository, ITopicRoutingService topicRoutingService) {
+
+      /*------------------------------------------------------------------------------------------------------------------------
+      | Validate input
+      \-----------------------------------------------------------------------------------------------------------------------*/
+      Contract.Requires(topicRepository != null, "A concrete implementation of an ITopicRepository is required.");
+      Contract.Requires(topicRoutingService != null, "A concrete implementation of an ITopicRoutingService is required.");
+
+      /*------------------------------------------------------------------------------------------------------------------------
+      | Set values locally
+      \-----------------------------------------------------------------------------------------------------------------------*/
       _topicRepository = topicRepository;
-      _currentTopic = currentTopic;
+      _topicRoutingService = topicRoutingService;
+
     }
 
     /*==========================================================================================================================
@@ -64,6 +77,9 @@ namespace Ignia.Topics.Web.Mvc {
     /// <returns>The Topic associated with the current request.</returns>
     protected Topic CurrentTopic {
       get {
+        if (_currentTopic == null) {
+          _currentTopic = _topicRoutingService.GetCurrentTopic();
+        }
         return _currentTopic;
       }
     }

--- a/Ignia.Topics.Web/Ignia.Topics.Web.csproj
+++ b/Ignia.Topics.Web/Ignia.Topics.Web.csproj
@@ -143,11 +143,11 @@
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="TopicRepository.cs" />
-    <Compile Include="ViewRoutingService.cs" />
     <Compile Include="TopicsRouteHandler.cs" />
     <Compile Include="TypedTopicPage.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
+    <Compile Include="WebFormsTopicRoutingService.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ignia.Topics\Ignia.Topics.csproj">

--- a/Ignia.Topics.Web/TopicPage.cs
+++ b/Ignia.Topics.Web/TopicPage.cs
@@ -69,8 +69,8 @@ namespace Ignia.Topics.Web {
             _topic = TopicRepository.RootTopic.GetTopic(path);
           }
           else {
-            var topicRoutingService = new ViewRoutingService(TopicRepository.DataProvider, Request.RequestContext);
-            _topic = topicRoutingService.Topic;
+            var topicRoutingService = new WebFormsTopicRoutingService(TopicRepository.DataProvider, Request.RequestContext);
+            _topic = topicRoutingService.GetCurrentTopic();
           }
         }
 

--- a/Ignia.Topics.Web/TopicsRouteHandler.cs
+++ b/Ignia.Topics.Web/TopicsRouteHandler.cs
@@ -84,9 +84,9 @@ namespace Ignia.Topics.Web {
       | Set variables
       \-----------------------------------------------------------------------------------------------------------------------*/
       var routeData             = requestContext.RouteData;
-      var viewRoutingService   = new ViewRoutingService(TopicRepository.DataProvider, requestContext, ViewsPath, "aspx");
-      var topic                 = viewRoutingService.Topic;
-      var viewName              = viewRoutingService.View;
+      var routingService        = new WebFormsTopicRoutingService(TopicRepository.DataProvider, requestContext, ViewsPath);
+      var topic                 = routingService.GetCurrentTopic();
+      var viewName              = routingService.View;
 
       /*------------------------------------------------------------------------------------------------------------------------
       | Validate path

--- a/Ignia.Topics/ITopicRoutingService.cs
+++ b/Ignia.Topics/ITopicRoutingService.cs
@@ -15,30 +15,22 @@ namespace Ignia.Topics {
   | INTERFACE: TOPIC ROUTING SERVICE
   \---------------------------------------------------------------------------------------------------------------------------*/
   /// <summary>
-  ///   Given contextual information (such as URL) will determine the current Topic, View, etc.
+  ///   Given contextual information (such as URL) will determine the current Topic.
   /// </summary>
   /// <remarks>
-  ///   The view location will change based on the environment. That said, in all cases, the view will factor in the topic's
-  ///   Content Type and (if set) View properties, and optionally the view determined via the URL (as either a URL part, or a
-  ///   query string parameter. For instance, a view can be set as /a/b/c/viewName/ or /a/b/c/?View=viewName.
+  ///   Each environment (e.g., ASP.NET MVC) will require a platform-specific <see cref="ITopicRoutingService"/> to act as an
+  ///   adapter to framework-specific libraries (e.g., <code>HttpContext</code>). In addition, custom versions may be created
+  ///   in order to establish custom mappings between URL or route data and the hierarchy of topics, should the need arise.
   /// </remarks>
   public interface ITopicRoutingService {
 
     /*==========================================================================================================================
-    | METHOD: TOPIC
+    | METHOD: GET CURRENT TOPIC
     \-------------------------------------------------------------------------------------------------------------------------*/
     /// <summary>
     ///   Gets the topic associated with the current URL.
     /// </summary>
-    Topic Topic { get; }
-
-    /*==========================================================================================================================
-    | PROPERTY: CONTENT TYPE
-    \-------------------------------------------------------------------------------------------------------------------------*/
-    /// <summary>
-    ///   Gets the content type associated with the topic associated with the current URL.
-    /// </summary>
-    string ContentType { get; }
+    Topic GetCurrentTopic();
 
     }
   }

--- a/Ignia.Topics/Ignia.Topics.csproj
+++ b/Ignia.Topics/Ignia.Topics.csproj
@@ -118,7 +118,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -152,7 +151,6 @@
     <Compile Include="AttributeValue.cs" />
     <Compile Include="Topic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TopicRoutingService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Refactored `ITopicRoutingService`, including the concrete implementations, and any references to them. Additionally updated `TopicController` to depend on the `ITopicRoutingService` instead of a `Topic` entity.

# `ITopicRoutingService`
Modified to expose `GetCurrentTopic()` instead of `Topic` and `ContentType`. This is preferred since `Topic` was, in effect, a method, and `ContentType` was just a convenience property for `Topic.ContentType`. 

# `TopicController`
Updated the `TopicController` (in `Ignia.Topic.Web.Mvc`) to depend on `ITopicRoutingService`. This is preferable to depending on `Topic`, since a) `Topic` is an Entity, b) `Topic` isn't an abstraction, and c) `Topic` could be null (e.g., for 404s, or general pages such as Sitemaps). `GetCurrentTopic()` may return null, but `ITopicRoutingService` can always be relied upon to be present.

# `MvcTopicRoutingService`
Moved from `Ignia.Topics.TopicRoutingService`, which used to be a shared base for both ASP.NET WebForms and MVC. Since the amount of duplicate code is quite small at this point, this allowed removing the dependency on `System.Web` in the `Ignia.Topics` project. Updated to implement `GetCurrentTopic()`.

# `WebFormsTopicRoutingService`
Renamed from `ViewTopicRoutingService` to `WebFormsTopicRoutingService` for clarity and consistency. Updated to implement `GetCurrentTopic()` directly, instead of inheriting it from `Ignia.Topics.TopicRoutingService`. Rewrote the comments to better articulate its role, and how it handles Dependency Injection.