### PR TITLE
3.8.1 (Patch): Return 301 for Nested Topics

### DIFF
--- a/Ignia.Topics.Data.Caching/Ignia.Topics.Data.Caching.csproj
+++ b/Ignia.Topics.Data.Caching/Ignia.Topics.Data.Caching.csproj
@@ -48,14 +48,6 @@
     <TargetFrameworkProfile />
     <ShouldCreateLogs>True</ShouldCreateLogs>
     <AdvancedSettingsExpanded>False</AdvancedSettingsExpanded>
-    <UpdateAssemblyVersion>True</UpdateAssemblyVersion>
-    <UpdateAssemblyFileVersion>True</UpdateAssemblyFileVersion>
-    <UpdateAssemblyInfoVersion>False</UpdateAssemblyInfoVersion>
-    <AssemblyVersionSettings>None.None.Increment.None</AssemblyVersionSettings>
-    <UpdatePackageVersion>False</UpdatePackageVersion>
-    <AssemblyInfoVersionType>SettingsVersion</AssemblyInfoVersionType>
-    <InheritWinAppVersionFrom>None</InheritWinAppVersionFrom>
-    <AssemblyFileVersionSettings>None.None.Increment.None</AssemblyFileVersionSettings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -158,8 +150,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props'))" />
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets'))" />
+    <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
   </Target>
   <Import Project="..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets" Condition="Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" />
+  <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Ignia.Topics.Data.Caching/Ignia.Topics.Data.Caching.nuspec
+++ b/Ignia.Topics.Data.Caching/Ignia.Topics.Data.Caching.nuspec
@@ -4,7 +4,7 @@
     <id>$id$</id>
     <version>$SemVer$</version>
     <title>$title$</title>
-    <authors>Ignia</authors>
+    <authors>$author$</authors>
     <owners>JeremyCaney</owners>
     <projectUrl>https://github.com/Ignia/Topics-Library</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Ignia.Topics.Data.Caching/Ignia.Topics.Data.Caching.nuspec
+++ b/Ignia.Topics.Data.Caching/Ignia.Topics.Data.Caching.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$SemVer$</version>
     <title>$title$</title>
     <authors>Ignia</authors>
     <owners>JeremyCaney</owners>

--- a/Ignia.Topics.Data.Caching/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Data.Caching/Properties/AssemblyInfo.cs
@@ -21,8 +21,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.6.1762.0")]
-[assembly: AssemblyFileVersion("3.5.1794.0")]
 [assembly: CLSCompliant(true)]
 [assembly: Guid("206b7f91-ca25-4e9d-9576-60d2e54a2c0a")]
 

--- a/Ignia.Topics.Data.Caching/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Data.Caching/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 >===============================================================================================================================
 | Declare and define attributes used in the compiling of the finished assembly.
 \-----------------------------------------------------------------------------------------------------------------------------*/
-[assembly: AssemblyCompany("Ignia, LLC")]
+[assembly: AssemblyCompany("Ignia")]
 [assembly: AssemblyCopyright("Copyright © 2018 Ignia, LLC")]
 [assembly: AssemblyProduct("Ignia OnTopic Library")]
 [assembly: AssemblyTitle("OnTopic Cached Repository")]

--- a/Ignia.Topics.Data.Sql/Ignia.Topics.Data.Sql.csproj
+++ b/Ignia.Topics.Data.Sql/Ignia.Topics.Data.Sql.csproj
@@ -208,8 +208,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props'))" />
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets'))" />
+    <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
   </Target>
   <Import Project="..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets" Condition="Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" />
+  <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Ignia.Topics.Data.Sql/Ignia.Topics.Data.Sql.nuspec
+++ b/Ignia.Topics.Data.Sql/Ignia.Topics.Data.Sql.nuspec
@@ -4,7 +4,7 @@
     <id>$id$</id>
     <version>$SemVer$</version>
     <title>$title$</title>
-    <authors>Ignia</authors>
+    <authors>$author$</authors>
     <owners>JeremyCaney</owners>
     <projectUrl>https://github.com/Ignia/Topics-Library</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Ignia.Topics.Data.Sql/Ignia.Topics.Data.Sql.nuspec
+++ b/Ignia.Topics.Data.Sql/Ignia.Topics.Data.Sql.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$SemVer$</version>
     <title>$title$</title>
     <authors>Ignia</authors>
     <owners>JeremyCaney</owners>

--- a/Ignia.Topics.Data.Sql/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Data.Sql/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 >===============================================================================================================================
 | Declare and define attributes used in the compiling of the finished assembly.
 \-----------------------------------------------------------------------------------------------------------------------------*/
-[assembly: AssemblyCompany("Ignia, LLC")]
+[assembly: AssemblyCompany("Ignia")]
 [assembly: AssemblyCopyright("Copyright © 2018 Ignia, LLC")]
 [assembly: AssemblyProduct("Ignia OnTopic Library")]
 [assembly: AssemblyTitle("Ignia SQL Server Repository")]

--- a/Ignia.Topics.Data.Sql/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Data.Sql/Properties/AssemblyInfo.cs
@@ -21,7 +21,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.6.1739.0")]
-[assembly: AssemblyFileVersion("3.5.1763.0")]
 [assembly: CLSCompliant(true)]
 [assembly: Guid("1de1f923-c7c2-435b-b49a-975acbcb5ff0")]

--- a/Ignia.Topics.Data.Sql/packages.config
+++ b/Ignia.Topics.Data.Sql/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CodeContracts.MSBuild" version="1.12.0" targetFramework="net45" developmentDependency="true" />
+  <package id="GitVersionTask" version="3.6.5" targetFramework="net47" developmentDependency="true" />
 </packages>

--- a/Ignia.Topics.Tests/Ignia.Topics.Tests.csproj
+++ b/Ignia.Topics.Tests/Ignia.Topics.Tests.csproj
@@ -22,14 +22,6 @@
     <TargetFrameworkProfile />
     <ShouldCreateLogs>True</ShouldCreateLogs>
     <AdvancedSettingsExpanded>False</AdvancedSettingsExpanded>
-    <UpdateAssemblyVersion>True</UpdateAssemblyVersion>
-    <UpdateAssemblyFileVersion>True</UpdateAssemblyFileVersion>
-    <UpdateAssemblyInfoVersion>False</UpdateAssemblyInfoVersion>
-    <AssemblyVersionSettings>None.None.Increment.None</AssemblyVersionSettings>
-    <UpdatePackageVersion>False</UpdatePackageVersion>
-    <AssemblyInfoVersionType>SettingsVersion</AssemblyInfoVersionType>
-    <InheritWinAppVersionFrom>None</InheritWinAppVersionFrom>
-    <AssemblyFileVersionSettings>None.None.Increment.None</AssemblyFileVersionSettings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Ignia.Topics.Tests/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Tests/Properties/AssemblyInfo.cs
@@ -21,7 +21,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.6.1791.0")]
-[assembly: AssemblyFileVersion("3.5.1839.0")]
 [assembly: CLSCompliant(true)]
 [assembly: Guid("27632801-bfe3-41d9-8678-3c4bbe45e6c9")]

--- a/Ignia.Topics.Tests/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Tests/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 >===============================================================================================================================
 | Declare and define attributes used in the compiling of the finished assembly.
 \-----------------------------------------------------------------------------------------------------------------------------*/
-[assembly: AssemblyCompany("Ignia, LLC")]
+[assembly: AssemblyCompany("Ignia")]
 [assembly: AssemblyCopyright("Copyright © 2018 Ignia, LLC")]
 [assembly: AssemblyProduct("Ignia OnTopic Library")]
 [assembly: AssemblyTitle("Ignia OnTopic Unit Tests")]

--- a/Ignia.Topics.ViewModels/Ignia.Topics.ViewModels.csproj
+++ b/Ignia.Topics.ViewModels/Ignia.Topics.ViewModels.csproj
@@ -14,14 +14,8 @@
     <TargetFrameworkProfile />
     <ShouldCreateLogs>True</ShouldCreateLogs>
     <AdvancedSettingsExpanded>False</AdvancedSettingsExpanded>
-    <UpdateAssemblyVersion>True</UpdateAssemblyVersion>
-    <UpdateAssemblyFileVersion>True</UpdateAssemblyFileVersion>
-    <UpdateAssemblyInfoVersion>False</UpdateAssemblyInfoVersion>
-    <AssemblyVersionSettings>None.None.Increment.None</AssemblyVersionSettings>
-    <UpdatePackageVersion>False</UpdatePackageVersion>
-    <AssemblyInfoVersionType>SettingsVersion</AssemblyInfoVersionType>
-    <InheritWinAppVersionFrom>None</InheritWinAppVersionFrom>
-    <AssemblyFileVersionSettings>None.None.Increment.None</AssemblyFileVersionSettings>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -79,7 +73,15 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Ignia.Topics.ViewModels.nuspec" />
+    <None Include="packages.config" />
     <None Include="README.md" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
 </Project>

--- a/Ignia.Topics.ViewModels/Ignia.Topics.ViewModels.nuspec
+++ b/Ignia.Topics.ViewModels/Ignia.Topics.ViewModels.nuspec
@@ -4,7 +4,7 @@
     <id>$id$</id>
     <version>$SemVer$</version>
     <title>$title$</title>
-    <authors>Ignia</authors>
+    <authors>$author$</authors>
     <owners>JeremyCaney</owners>
     <projectUrl>https://github.com/Ignia/Topics-Library</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Ignia.Topics.ViewModels/Ignia.Topics.ViewModels.nuspec
+++ b/Ignia.Topics.ViewModels/Ignia.Topics.ViewModels.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$SemVer$</version>
     <title>$title$</title>
     <authors>Ignia</authors>
     <owners>JeremyCaney</owners>

--- a/Ignia.Topics.ViewModels/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.ViewModels/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 >===============================================================================================================================
 | Declare and define attributes used in the compiling of the finished assembly.
 \-----------------------------------------------------------------------------------------------------------------------------*/
-[assembly: AssemblyCompany("Ignia, LLC")]
+[assembly: AssemblyCompany("Ignia")]
 [assembly: AssemblyCopyright("Copyright © 2018 Ignia, LLC")]
 [assembly: AssemblyProduct("Ignia OnTopic Library")]
 [assembly: AssemblyTitle("Ignia OnTopic View Models")]

--- a/Ignia.Topics.ViewModels/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.ViewModels/Properties/AssemblyInfo.cs
@@ -21,8 +21,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.6.1762.0")]
-[assembly: AssemblyFileVersion("3.5.1793.0")]
 [assembly: CLSCompliant(true)]
 [assembly: Guid("e52fc633-b4c5-4a2b-8caf-30e756d7a6a7")]
 

--- a/Ignia.Topics.ViewModels/packages.config
+++ b/Ignia.Topics.ViewModels/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CodeContracts.MSBuild" version="1.12.0" targetFramework="net45" developmentDependency="true" />
   <package id="GitVersionTask" version="3.6.5" targetFramework="net47" developmentDependency="true" />
 </packages>

--- a/Ignia.Topics.Web.Mvc/Controllers/TopicController.cs
+++ b/Ignia.Topics.Web.Mvc/Controllers/TopicController.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using Ignia.Topics.Mapping;
@@ -151,7 +152,18 @@ namespace Ignia.Topics.Web.Mvc.Controllers {
       }
 
       /*------------------------------------------------------------------------------------------------------------------------
-      | Handle page group
+      | Handle nested topics
+      >-----------------------------------------------------------------------------------------------------------------------—-
+      | Nested topics are not expected to be viewed directly; if a user requests a nested topic, return a 403 to indicate that
+      | the request is valid, but forbidden.
+      \-----------------------------------------------------------------------------------------------------------------------*/
+      if (CurrentTopic.ContentType.Equals("List") || CurrentTopic.Parent.ContentType.Equals("List")) {
+        filterContext.Result = new HttpStatusCodeResult(HttpStatusCode.Forbidden);
+        return;
+      }
+
+      /*------------------------------------------------------------------------------------------------------------------------
+      | Handle page groups
       >-----------------------------------------------------------------------------------------------------------------------—-
       | PageGroups are a special content type for packaging multiple pages together. When a PageGroup is identified, the user is
       | redirected to the first (non-hidden, non-disabled) page in the page group.

--- a/Ignia.Topics.Web.Mvc/Ignia.Topics.Web.Mvc.csproj
+++ b/Ignia.Topics.Web.Mvc/Ignia.Topics.Web.Mvc.csproj
@@ -17,14 +17,6 @@
     </NuGetPackageImportStamp>
     <ShouldCreateLogs>True</ShouldCreateLogs>
     <AdvancedSettingsExpanded>False</AdvancedSettingsExpanded>
-    <UpdateAssemblyVersion>True</UpdateAssemblyVersion>
-    <UpdateAssemblyFileVersion>True</UpdateAssemblyFileVersion>
-    <UpdateAssemblyInfoVersion>False</UpdateAssemblyInfoVersion>
-    <AssemblyVersionSettings>None.None.Increment.None</AssemblyVersionSettings>
-    <UpdatePackageVersion>False</UpdatePackageVersion>
-    <AssemblyInfoVersionType>SettingsVersion</AssemblyInfoVersionType>
-    <InheritWinAppVersionFrom>None</InheritWinAppVersionFrom>
-    <AssemblyFileVersionSettings>None.None.Increment.None</AssemblyFileVersionSettings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -107,8 +99,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props'))" />
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets'))" />
+    <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
   </Target>
   <Import Project="..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets" Condition="Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" />
+  <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Ignia.Topics.Web.Mvc/Ignia.Topics.Web.Mvc.nuspec
+++ b/Ignia.Topics.Web.Mvc/Ignia.Topics.Web.Mvc.nuspec
@@ -4,7 +4,7 @@
     <id>$id$</id>
     <version>$SemVer$</version>
     <title>$title$</title>
-    <authors>Ignia</authors>
+    <authors>$author$</authors>
     <owners>JeremyCaney</owners>
     <projectUrl>https://github.com/Ignia/Topics-Library</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Ignia.Topics.Web.Mvc/Ignia.Topics.Web.Mvc.nuspec
+++ b/Ignia.Topics.Web.Mvc/Ignia.Topics.Web.Mvc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$SemVer$</version>
     <title>$title$</title>
     <authors>Ignia</authors>
     <owners>JeremyCaney</owners>

--- a/Ignia.Topics.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Web.Mvc/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 >===============================================================================================================================
 | Declare and define attributes used in the compiling of the finished assembly.
 \-----------------------------------------------------------------------------------------------------------------------------*/
-[assembly: AssemblyCompany("Ignia, LLC")]
+[assembly: AssemblyCompany("Ignia")]
 [assembly: AssemblyCopyright("Copyright © 2015 Ignia, LLC")]
 [assembly: AssemblyProduct("Ignia OnTopic Library")]
 [assembly: AssemblyTitle("Ignia OnTopic MVC Library")]

--- a/Ignia.Topics.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Web.Mvc/Properties/AssemblyInfo.cs
@@ -21,7 +21,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.6.1767.0")]
-[assembly: AssemblyFileVersion("3.5.1799.0")]
 [assembly: CLSCompliant(true)]
 [assembly: Guid("3b3ce34d-b5e5-47ca-bfef-e6740650f378")]

--- a/Ignia.Topics.Web.Mvc/TopicViewEngine.cs
+++ b/Ignia.Topics.Web.Mvc/TopicViewEngine.cs
@@ -33,6 +33,8 @@ namespace Ignia.Topics.Web.Mvc {
 
       /*------------------------------------------------------------------------------------------------------------------------
       | Define view location
+      >-------------------------------------------------------------------------------------------------------------------------
+      | Supports the following replacement tokens: {0} Controller, {1} View, {2} Area, and {3} Content Type.
       \-----------------------------------------------------------------------------------------------------------------------*/
       var viewLocations = new[] {
         "~/Views/{3}/{1}.cshtml",
@@ -174,7 +176,7 @@ namespace Ignia.Topics.Web.Mvc {
         area = routeData.GetRequiredString("area");
       }
       if (routeData.Values.ContainsKey("controller")) {
-        area = routeData.GetRequiredString("controller");
+        controller = routeData.GetRequiredString("controller");
       }
       if (routeData.Values.ContainsKey("contenttype")) {
         routeData.Values.TryGetValue("contenttype", out contentType);

--- a/Ignia.Topics.Web.Mvc/packages.config
+++ b/Ignia.Topics.Web.Mvc/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CodeContracts.MSBuild" version="1.12.0" targetFramework="net45" developmentDependency="true" />
+  <package id="GitVersionTask" version="3.6.5" targetFramework="net47" developmentDependency="true" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.4" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.4" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net45" />

--- a/Ignia.Topics.Web/Ignia.Topics.Web.csproj
+++ b/Ignia.Topics.Web/Ignia.Topics.Web.csproj
@@ -50,14 +50,6 @@
     <NoWarn>CS0618</NoWarn>
     <ShouldCreateLogs>True</ShouldCreateLogs>
     <AdvancedSettingsExpanded>False</AdvancedSettingsExpanded>
-    <UpdateAssemblyVersion>True</UpdateAssemblyVersion>
-    <UpdateAssemblyFileVersion>True</UpdateAssemblyFileVersion>
-    <UpdateAssemblyInfoVersion>False</UpdateAssemblyInfoVersion>
-    <AssemblyFileVersionSettings>None.None.Increment.None</AssemblyFileVersionSettings>
-    <UpdatePackageVersion>False</UpdatePackageVersion>
-    <AssemblyInfoVersionType>SettingsVersion</AssemblyInfoVersionType>
-    <InheritWinAppVersionFrom>None</InheritWinAppVersionFrom>
-    <AssemblyVersionSettings>None.None.Increment.None</AssemblyVersionSettings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -178,8 +170,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props'))" />
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets'))" />
+    <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
   </Target>
   <Import Project="..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets" Condition="Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" />
+  <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Ignia.Topics.Web/Ignia.Topics.Web.nuspec
+++ b/Ignia.Topics.Web/Ignia.Topics.Web.nuspec
@@ -4,7 +4,7 @@
     <id>$id$</id>
     <version>$SemVer$</version>
     <title>$title$</title>
-    <authors>Ignia</authors>
+    <authors>$author$</authors>
     <owners>JeremyCaney</owners>
     <projectUrl>https://github.com/Ignia/Topics-Library</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Ignia.Topics.Web/Ignia.Topics.Web.nuspec
+++ b/Ignia.Topics.Web/Ignia.Topics.Web.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$SemVer$</version>
     <title>$title$</title>
     <authors>Ignia</authors>
     <owners>JeremyCaney</owners>

--- a/Ignia.Topics.Web/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Web/Properties/AssemblyInfo.cs
@@ -21,7 +21,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.6.1759.0")]
-[assembly: AssemblyFileVersion("3.5.1783.0")]
 [assembly: CLSCompliant(true)]
 [assembly: Guid("c98f7b48-a085-4394-b820-c244f23868ce")]

--- a/Ignia.Topics.Web/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics.Web/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 >===============================================================================================================================
 | Declare and define attributes used in the compiling of the finished assembly.
 \-----------------------------------------------------------------------------------------------------------------------------*/
-[assembly: AssemblyCompany("Ignia, LLC")]
+[assembly: AssemblyCompany("Ignia")]
 [assembly: AssemblyCopyright("Copyright © 2015 Ignia, LLC")]
 [assembly: AssemblyProduct("Ignia OnTopic Library")]
 [assembly: AssemblyTitle("Ignia OnTopic WebForms Library")]

--- a/Ignia.Topics.Web/packages.config
+++ b/Ignia.Topics.Web/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CodeContracts.MSBuild" version="1.12.0" targetFramework="net45" developmentDependency="true" />
+  <package id="GitVersionTask" version="3.6.5" targetFramework="net47" developmentDependency="true" />
 </packages>

--- a/Ignia.Topics/Ignia.Topics.csproj
+++ b/Ignia.Topics/Ignia.Topics.csproj
@@ -49,14 +49,6 @@
     <CodeContractsBaseLineFile />
     <ShouldCreateLogs>True</ShouldCreateLogs>
     <AdvancedSettingsExpanded>False</AdvancedSettingsExpanded>
-    <UpdateAssemblyVersion>True</UpdateAssemblyVersion>
-    <UpdateAssemblyFileVersion>True</UpdateAssemblyFileVersion>
-    <UpdateAssemblyInfoVersion>False</UpdateAssemblyInfoVersion>
-    <AssemblyVersionSettings>None.None.Increment.None</AssemblyVersionSettings>
-    <UpdatePackageVersion>False</UpdatePackageVersion>
-    <AssemblyInfoVersionType>SettingsVersion</AssemblyInfoVersionType>
-    <InheritWinAppVersionFrom>None</InheritWinAppVersionFrom>
-    <AssemblyFileVersionSettings>None.None.Increment.None</AssemblyFileVersionSettings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -206,8 +198,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.props'))" />
     <Error Condition="!Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets'))" />
+    <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
   </Target>
   <Import Project="..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets" Condition="Exists('..\packages\CodeContracts.MSBuild.1.12.0\build\CodeContracts.MSBuild.targets')" />
+  <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Ignia.Topics/Ignia.Topics.nuspec
+++ b/Ignia.Topics/Ignia.Topics.nuspec
@@ -4,7 +4,7 @@
     <id>$id$</id>
     <version>$SemVer$</version>
     <title>$title$</title>
-    <authors>Ignia</authors>
+    <authors>$author$</authors>
     <owners>JeremyCaney</owners>
     <projectUrl>https://github.com/Ignia/Topics-Library</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Ignia.Topics/Ignia.Topics.nuspec
+++ b/Ignia.Topics/Ignia.Topics.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$id$</id>
-    <version>$version$</version>
+    <version>$SemVer$</version>
     <title>$title$</title>
     <authors>Ignia</authors>
     <owners>JeremyCaney</owners>

--- a/Ignia.Topics/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 >===============================================================================================================================
 | Declare and define attributes used in the compiling of the finished assembly.
 \-----------------------------------------------------------------------------------------------------------------------------*/
-[assembly: AssemblyCompany("Ignia, LLC")]
+[assembly: AssemblyCompany("Ignia")]
 [assembly: AssemblyCopyright("Copyright © 2018 Ignia, LLC")]
 [assembly: AssemblyProduct("Ignia OnTopic Library")]
 [assembly: AssemblyTitle("Ignia OnTopic Library")]

--- a/Ignia.Topics/Properties/AssemblyInfo.cs
+++ b/Ignia.Topics/Properties/AssemblyInfo.cs
@@ -22,8 +22,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.6.1762.0")]
-[assembly: AssemblyFileVersion("3.5.1794.0")]
 [assembly: InternalsVisibleTo("Ignia.Topics.Tests")]
 [assembly: CLSCompliant(true)]
 [assembly: GuidAttribute("3CA9F6CB-B45A-4E74-AAA4-0C87CAA2704F")]

--- a/Ignia.Topics/README.md
+++ b/Ignia.Topics/README.md
@@ -1,4 +1,9 @@
 ﻿# `Ignia.Topics`
+
+![Continuous Integration (CI) Build status](https://igniasoftware.visualstudio.com/_apis/public/build/definitions/bd7f03e0-6fcf-4ec6-939d-4e995668d40f/1/badge)
+![NuGet Deployment Status](https://rmsprodscussu1.vsrm.visualstudio.com/A09668467-721c-4517-8d2e-aedbe2a7d67f/_apis/public/Release/badge/bd7f03e0-6fcf-4ec6-939d-4e995668d40f/2/2)
+[![Ignia.Topics package in Internal feed in Visual Studio Team Services](https://feedsprodcus1.feeds.visualstudio.com/A09668467-721c-4517-8d2e-aedbe2a7d67f/_apis/public/Packaging/Feeds/46d5f49c-5e1e-47bb-8b14-43be6c719ba8/Packages/c4d6e7c6-5328-4794-8ce2-608c9c557052/Badge)](https://igniasoftware.visualstudio.com/_Packaging?feed=46d5f49c-5e1e-47bb-8b14-43be6c719ba8&package=c4d6e7c6-5328-4794-8ce2-608c9c557052&preferRelease=true&_a=package) 
+
 The `Ignia.Topics` assembly represents the core domain layer of the OnTopic library. It includes the primary entity ([`Topic`](Topic.cs)), abstractions (e.g., [`ITopicRepository`](Repositories/ITopicRepository.cs)), and associated classes (e.g., [`TopicCollection<>`](Collections/TopicCollection{T}.cs)).
 
 ## Entities

--- a/Ignia.Topics/packages.config
+++ b/Ignia.Topics/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CodeContracts.MSBuild" version="1.12.0" targetFramework="net45" developmentDependency="true" />
+  <package id="GitVersionTask" version="3.6.5" targetFramework="net47" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Currently, when a user requests a Nested Topic, they will be routed to the `TopicController`, which won't be able to process the request since, by design, Nested Topics aren't associated with views. To mitigate this, the patch will instead return a 403 error as part of a validation filter in the `TopicController` class. This is a more appropriate error, and will make it easier to filter these out when analyzing log files in e.g. **Application Insights**.